### PR TITLE
Adds more supported chains and update API endpoint URLs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -77,9 +77,16 @@ class App extends Component {
         return utils.adjustV(sig);
     }
 
+    formatBaseURL() {
+        if (this.props.web3ReactHookValue.chainId === 250) {
+            return `${this.state.txBaseUrl}/v1/chains/250`;
+        }
+        return `${this.state.txBaseUrl}/api/v1`;
+    }
+
     async fetchDelegates() {
         const account = this.state.safeAccount;
-        fetch(`${this.state.txBaseUrl}/api/v1/safes/${account}/delegates/`)
+        fetch(`${this.formatBaseURL()}/delegates/?safe=${account}`)
             .then((response) => response.json())
             .then(data => {
                 this.setState({delegates: data.results});
@@ -98,11 +105,12 @@ class App extends Component {
             body: JSON.stringify({
                 "safe": account,
                 "delegate": delegate,
+                "delegator": this.props.web3ReactHookValue.account,
                 "signature": signature,
                 "label": label
             })
         };
-        fetch(`${this.state.txBaseUrl}/api/v1/safes/${account}/delegates/`, requestOptions)
+        fetch(`${this.formatBaseURL()}/delegates/`, requestOptions)
             .then(response => response.json())
             .then(data => {
                 this.setState({"addDelegate": "", "addLabel": ""})
@@ -119,10 +127,12 @@ class App extends Component {
             method: 'DELETE',
             headers: { 'Content-type': 'application/json' },
             body: JSON.stringify({
+                "safe": account,
+                "delegate": delegate,
                 "signature": signature
             })
         };
-        fetch(`${this.state.txBaseUrl}/api/v1/safes/${account}/delegates/${delegate}/`, requestOptions)
+        fetch(`${this.formatBaseURL()}/safes/${account}/delegates/${delegate}/`, requestOptions)
             .then(response => {
                 this.setState({"removeDelegate": ""})
                 this.fetchDelegates();
@@ -134,7 +144,7 @@ class App extends Component {
             alert("You need to firstly connect to your wallet.");
             return
         }
-        fetch(`${this.state.txBaseUrl}/api/v1/owners/${this.props.web3ReactHookValue.account}/safes/`)
+        fetch(`${this.formatBaseURL()}/owners/${this.props.web3ReactHookValue.account}/safes/`)
             .then(response => response.json())
             .then(data => {
                 let checksumData = []

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,7 @@ const {getAddress} = require("@ethersproject/address");
 const NETWORK = {
     "mainnet": {
         CHAINID: 1,
-        TX_SERVICE_BASE_URL: "https://safe-transaction.mainnet.gnosis.io",
+        TX_SERVICE_BASE_URL: "https://safe-transaction-mainnet.safe.global",
     },
     "rinkeby": {
         CHAINID: 4,
@@ -11,23 +11,23 @@ const NETWORK = {
     },
     "goerli": {
         CHAINID: 5,
-        TX_SERVICE_BASE_URL: "https://safe-transaction.goerli.gnosis.io",
+        TX_SERVICE_BASE_URL: "https://safe-transaction-goerli.safe.global",
     },
     "xdai": {
         CHAINID: 100,
-        TX_SERVICE_BASE_URL: "https://safe-transaction.xdai.gnosis.io",
+        TX_SERVICE_BASE_URL: "https://safe-transaction-gnosis-chain.safe.global",
     },
     "matic": {
         CHAINID: 137,
-        TX_SERVICE_BASE_URL: "https://safe-transaction.polygon.gnosis.io",
+        TX_SERVICE_BASE_URL: "https://safe-transaction-polygon.safe.global",
     },
     "binance": {
         CHAINID: 56,
-        TX_SERVICE_BASE_URL: "https://safe-transaction.bsc.gnosis.io",
+        TX_SERVICE_BASE_URL: "https://safe-transaction-bsc.safe.global",
     },
     "arbitrum": {
         CHAINID: 42161,
-        TX_SERVICE_BASE_URL: "https://safe-transaction.arbitrum.gnosis.io",
+        TX_SERVICE_BASE_URL: "https://safe-transaction-arbitrum.safe.global",
     },
     "fantom": {
         CHAINID: 250,
@@ -35,8 +35,20 @@ const NETWORK = {
     },
     "optimism": {
         CHAINID: 10,
-        TX_SERVICE_BASE_URL: "https://safe-transaction.optimism.gnosis.io/",
+        TX_SERVICE_BASE_URL: "https://safe-transaction-optimism.safe.global",
     },
+    "avalanche": {
+        CHAINID: 43114,
+        TX_SERVICE_BASE_URL: "https://safe-transaction-avalanche.safe.global",
+    },
+    "evmos": {
+        CHAINID: 9001,
+        TX_SERVICE_BASE_URL: "https://transaction.safe.evmos.org",
+    },
+    "aurora": {
+        CHAINID: 1313161554,
+        TX_SERVICE_BASE_URL: "https://safe-transaction-aurora.safe.global",
+    }
 }
 
 function getSupportedChainID() {


### PR DESCRIPTION
Adds three more networks
* Avax
* Evmos (gnosis fork)
* Aurora

Also updates existing URLs to the new domains according to the migration post.
https://forum.gnosis-safe.io/t/transaction-service-migration-october-2022/1550

Replaces deprecated API paths with current ones.
https://safe-transaction-mainnet.safe.global/