### PR TITLE
Add Sepolia network support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.idea
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/utils.js
+++ b/src/utils.js
@@ -48,6 +48,10 @@ const NETWORK = {
     "aurora": {
         CHAINID: 1313161554,
         TX_SERVICE_BASE_URL: "https://safe-transaction-aurora.safe.global",
+    },
+    "sepolia": {
+        CHAINID: 11155111,
+        TX_SERVICE_BASE_URL: "https://safe-transaction-sepolia.safe.global"
     }
 }
 


### PR DESCRIPTION
## What it solves

Adds support for sepolia testnet

## How to test it

1. Start the app
2. Observe Sepolia in the list of networks
3. Connect with your wallet on Sepolia
4. Fetch all safes
5. Observe results contain Safes on Sepolia
6. Add a delegate
7. Observe no error